### PR TITLE
fix: add regex support for plain report tables

### DIFF
--- a/source/__tests__/index.test.ts
+++ b/source/__tests__/index.test.ts
@@ -31,6 +31,22 @@ function createTable(pkg: string): string {
   `;
 }
 
+function createPlainTable(pkg: string): string {
+  return `
+    High            Arbitrary File Overwrite
+
+    Package         ${pkg}${' '.repeat(62 - 1 - pkg.length)}
+
+    Patched in      version
+
+    Dependency of   package
+
+    Path            path
+
+    More info       link
+  `;
+}
+
 let callCount = 0;
 
 beforeEach(() => {
@@ -50,42 +66,48 @@ describe('fail states', () => {
     await expect({}).not.toPassPackageAudit();
   });
 
-  test('vulnerability output', async () => {
-    mockSpawn.sequence.add(mockSpawn.simple(8, createTable('module')));
-    callCount++;
-    await expect({}).not.toPassPackageAudit();
-  });
+  describe.each([
+    ['bordered table', createTable],
+    ['plain table', createPlainTable],
+  ])('test %s', (_name, tableFn) => {
+    test('vulnerability output', async () => {
+      mockSpawn.sequence.add(mockSpawn.simple(8, tableFn('module')));
+      callCount++;
+      await expect({}).not.toPassPackageAudit();
+    });
 
-  test('vulnerability output 1 allowed', async () => {
-    mockSpawn.sequence.add(mockSpawn.simple(1, createTable('module')));
-    callCount++;
-    await expect({}).toPassPackageAudit({ allow: ['module'] });
-  });
+    test('vulnerability output 1 allowed', async () => {
+      mockSpawn.sequence.add(mockSpawn.simple(1, tableFn('module')));
+      callCount++;
+      await expect({}).toPassPackageAudit({ allow: ['module'] });
+    });
 
-  test('multiple vulnerability output', async () => {
-    mockSpawn.sequence.add(
-      mockSpawn.simple(
-        8,
-        createTable('module') + createTable('package') + createTable('example')
-      )
-    );
-    callCount++;
-    await expect({}).not.toPassPackageAudit();
-  });
+    test('multiple vulnerability output', async () => {
+      mockSpawn.sequence.add(
+        mockSpawn.simple(
+          8,
+          tableFn('module') + tableFn('package') + tableFn('example')
+        )
+      );
+      callCount++;
+      await expect({}).not.toPassPackageAudit();
+    });
 
-  test('multiple vulnerability output 1 allowed', async () => {
-    mockSpawn.sequence.add(
-      mockSpawn.simple(
-        8,
-        createTable('module') + createTable('package') + createTable('example')
-      )
-    );
-    callCount++;
-    await expect({}).not.toPassPackageAudit({
-      allow: ['package'],
+    test('multiple vulnerability output 1 allowed', async () => {
+      mockSpawn.sequence.add(
+        mockSpawn.simple(
+          8,
+          tableFn('module') + tableFn('package') + tableFn('example')
+        )
+      );
+      callCount++;
+      await expect({}).not.toPassPackageAudit({
+        allow: ['package'],
+      });
     });
   });
 });
+
 describe('pass states', () => {
   test('no output', async () => {
     mockSpawn.sequence.add(mockSpawn.simple(0));
@@ -99,28 +121,33 @@ describe('pass states', () => {
     await expect({}).toPassPackageAudit();
   });
 
-  test('vulnerability output allowed', async () => {
-    mockSpawn.sequence.add(mockSpawn.simple(8, createTable('module')));
-    callCount++;
-    await expect({}).toPassPackageAudit({ allow: ['module'] });
-  });
+  describe.each([
+    ['bordered table', createTable],
+    ['plain table', createPlainTable],
+  ])('test %s', (_name, tableFn) => {
+    test('vulnerability output allowed', async () => {
+      mockSpawn.sequence.add(mockSpawn.simple(8, tableFn('module')));
+      callCount++;
+      await expect({}).toPassPackageAudit({ allow: ['module'] });
+    });
 
-  test('vulnerability output allowed exit code 2', async () => {
-    mockSpawn.sequence.add(mockSpawn.simple(2, createTable('module')));
-    callCount++;
-    await expect({}).toPassPackageAudit({ allow: ['module'] });
-  });
+    test('vulnerability output allowed exit code 2', async () => {
+      mockSpawn.sequence.add(mockSpawn.simple(2, tableFn('module')));
+      callCount++;
+      await expect({}).toPassPackageAudit({ allow: ['module'] });
+    });
 
-  test('multiple vulnerability output allowed', async () => {
-    mockSpawn.sequence.add(
-      mockSpawn.simple(
-        8,
-        createTable('module') + createTable('package') + createTable('example')
-      )
-    );
-    callCount++;
-    await expect({}).toPassPackageAudit({
-      allow: ['module', 'package', 'example'],
+    test('multiple vulnerability output allowed', async () => {
+      mockSpawn.sequence.add(
+        mockSpawn.simple(
+          8,
+          tableFn('module') + tableFn('package') + tableFn('example')
+        )
+      );
+      callCount++;
+      await expect({}).toPassPackageAudit({
+        allow: ['module', 'package', 'example'],
+      });
     });
   });
 });

--- a/source/index.ts
+++ b/source/index.ts
@@ -19,7 +19,7 @@ export interface OutputOptions {
   allow?: string[];
 }
 
-const packageRegex = /^\s*│\s*Package\s*│\s*(\S+)\s*│\s*$/gm;
+const packageRegex = /^\s*│?\s*Package\s*│?\s*(\S+)\s*│?\s*$/gm;
 
 /**
  * Checks if the yarn/npm audit commands pass.


### PR DESCRIPTION
When running `npm audit` in a docker container, the audit table can be rendered without borders. This causes the `allow` list to be ignored. This is addressed by making the pipe an optional character when performing the regex 👀

<img width="734" alt="Screenshot 2020-06-29 at 20 21 24" src="https://user-images.githubusercontent.com/3706842/86047265-8f20f400-ba46-11ea-9974-e65cd73abd41.png">
