### PR TITLE
fix: manually filter severity levels

### DIFF
--- a/source/helpers/__tests__/getCommand.test.ts
+++ b/source/helpers/__tests__/getCommand.test.ts
@@ -1,5 +1,6 @@
 import getCommand from '../getCommand';
 import * as isYarn from '../isYarn';
+import { Severity } from '../../../source/static';
 
 const isYarnSpy = jest.spyOn(isYarn, 'default');
 
@@ -8,87 +9,81 @@ beforeEach(() => {
   isYarnSpy.mockReturnValue(Promise.resolve(false));
 });
 
-test('default npm', async () => {
-  await expect(getCommand('', {})).resolves.toBe('npm audit');
+test('npm', () => {
+  expect(getCommand('', { yarn: false })).toBe('npm audit');
 });
 
-test('npm', async () => {
-  await expect(getCommand('', { yarn: false })).resolves.toBe('npm audit');
+test('npm --audit-level', () => {
+  expect(
+    getCommand('/path/to/root', { yarn: false, level: Severity.INFO })
+  ).toBe('npm audit');
+  expect(
+    getCommand('/path/to/root', { yarn: false, level: Severity.LOW })
+  ).toBe('npm audit --audit-level=low');
+  expect(
+    getCommand('/path/to/root', { yarn: false, level: Severity.MODERATE })
+  ).toBe('npm audit --audit-level=moderate');
+  expect(
+    getCommand('/path/to/root', { yarn: false, level: Severity.HIGH })
+  ).toBe('npm audit --audit-level=high');
+  expect(
+    getCommand('/path/to/root', { yarn: false, level: Severity.CRITICAL })
+  ).toBe('npm audit --audit-level=critical');
 });
 
-test('npm --audit-level', async () => {
-  await expect(getCommand('/path/to/root', { level: 'info' })).resolves.toBe(
-    'npm audit'
+test('npm --only', () => {
+  expect(
+    getCommand('/path/to/root', {
+      yarn: false,
+      dependencyType: 'devDependencies',
+    })
+  ).toBe('npm audit --only=dev');
+  expect(getCommand('/path/to/root', { dependencyType: 'dependencies' })).toBe(
+    'npm audit --only=prod'
   );
-  await expect(getCommand('/path/to/root', { level: 'low' })).resolves.toBe(
-    'npm audit --audit-level=low'
+});
+
+test('yarn', () => {
+  expect(getCommand('', { yarn: true })).toBe('yarn audit');
+});
+
+test('yarn --level', () => {
+  expect(
+    getCommand('/path/to/root', { yarn: true, level: Severity.INFO })
+  ).toBe('yarn audit --level info');
+  expect(getCommand('/path/to/root', { yarn: true, level: Severity.LOW })).toBe(
+    'yarn audit --level low'
   );
-  await expect(
-    getCommand('/path/to/root', { level: 'moderate' })
-  ).resolves.toBe('npm audit --audit-level=moderate');
-  await expect(getCommand('/path/to/root', { level: 'high' })).resolves.toBe(
-    'npm audit --audit-level=high'
-  );
-  await expect(
-    getCommand('/path/to/root', { level: 'critical' })
-  ).resolves.toBe('npm audit --audit-level=critical');
+  expect(
+    getCommand('/path/to/root', { yarn: true, level: Severity.MODERATE })
+  ).toBe('yarn audit --level moderate');
+  expect(
+    getCommand('/path/to/root', { yarn: true, level: Severity.HIGH })
+  ).toBe('yarn audit --level high');
+  expect(
+    getCommand('/path/to/root', { yarn: true, level: Severity.CRITICAL })
+  ).toBe('yarn audit --level critical');
 });
 
-test('npm --only', async () => {
-  await expect(
-    getCommand('/path/to/root', { dependencyType: 'devDependencies' })
-  ).resolves.toBe('npm audit --only=dev');
-  await expect(
-    getCommand('/path/to/root', { dependencyType: 'dependencies' })
-  ).resolves.toBe('npm audit --only=prod');
-});
-
-test('default yarn', async () => {
-  isYarnSpy.mockReturnValueOnce(Promise.resolve(true));
-  await expect(getCommand('', {})).resolves.toBe('yarn audit');
-});
-
-test('yarn', async () => {
-  await expect(getCommand('', { yarn: true })).resolves.toBe('yarn audit');
-});
-
-test('yarn --level', async () => {
-  await expect(
-    getCommand('/path/to/root', { yarn: true, level: 'info' })
-  ).resolves.toBe('yarn audit --level info');
-  await expect(
-    getCommand('/path/to/root', { yarn: true, level: 'low' })
-  ).resolves.toBe('yarn audit --level low');
-  await expect(
-    getCommand('/path/to/root', { yarn: true, level: 'moderate' })
-  ).resolves.toBe('yarn audit --level moderate');
-  await expect(
-    getCommand('/path/to/root', { yarn: true, level: 'high' })
-  ).resolves.toBe('yarn audit --level high');
-  await expect(
-    getCommand('/path/to/root', { yarn: true, level: 'critical' })
-  ).resolves.toBe('yarn audit --level critical');
-});
-
-test('npm --groups', async () => {
-  await expect(
+test('npm --groups', () => {
+  expect(
     getCommand('/path/to/root', {
       yarn: true,
       dependencyType: 'devDependencies',
     })
-  ).resolves.toBe('yarn audit --groups devDependencies');
-  await expect(
+  ).toBe('yarn audit --groups devDependencies');
+  expect(
     getCommand('/path/to/root', { yarn: true, dependencyType: 'dependencies' })
-  ).resolves.toBe('yarn audit --groups dependencies');
+  ).toBe('yarn audit --groups dependencies');
 });
 
-test('command takes precedence', async () => {
-  await expect(
+test('command takes precedence', () => {
+  expect(
     getCommand('/path/to/root', {
       command: 'pnpm audit --dev',
       yarn: true,
-      level: 'info',
+      level: Severity.INFO,
       dependencyType: 'dependencies',
     })
-  ).resolves.toBe('pnpm audit --dev');
+  ).toBe('pnpm audit --dev');
 });

--- a/source/helpers/__tests__/severityGreater.test.ts
+++ b/source/helpers/__tests__/severityGreater.test.ts
@@ -1,0 +1,20 @@
+import severityGreater from '../severityGreater';
+import { Severity } from '../../static';
+
+test('equal', () => {
+  expect(severityGreater({ level: Severity.LOW }, Severity.LOW)).toBe(true);
+});
+
+test('greater', () => {
+  expect(severityGreater({ level: Severity.LOW }, Severity.HIGH)).toBe(true);
+});
+
+test('less', () => {
+  expect(severityGreater({ level: Severity.CRITICAL }, Severity.MODERATE)).toBe(
+    false
+  );
+});
+
+test('invalid severity', () => {
+  expect(severityGreater({ level: Severity.INFO }, 'invalid')).toBe(true);
+});

--- a/source/helpers/getCommand.ts
+++ b/source/helpers/getCommand.ts
@@ -1,5 +1,4 @@
 import { InputOptions } from 'source/static';
-import isYarn from './isYarn';
 
 /**
  * Gets the audit command string from the given options.
@@ -8,15 +7,14 @@ import isYarn from './isYarn';
  * @param inputOptions - Options for running the audit.
  * @returns Audit command string to run.
  */
-export default async function getCommand(
+export default function getCommand(
   root: string,
-  inputOptions?: InputOptions
-): Promise<string> {
-  if (inputOptions?.command) {
+  inputOptions: InputOptions
+): string {
+  if (inputOptions.command) {
     return inputOptions.command;
   }
-  const { yarn = await isYarn(root), level, dependencyType } =
-    inputOptions || {};
+  const { yarn, level, dependencyType } = inputOptions || {};
   let command;
   if (yarn) {
     command = 'yarn audit';

--- a/source/helpers/severityGreater.ts
+++ b/source/helpers/severityGreater.ts
@@ -1,0 +1,34 @@
+import { Severity, InputOptions } from '../static';
+
+const severityCascade: string[] = [
+  Severity.INFO,
+  Severity.LOW,
+  Severity.MODERATE,
+  Severity.HIGH,
+  Severity.CRITICAL,
+];
+
+/**
+ * Checks if a severity is greater than the configured one.
+ *
+ * @param inputOptions - Options for running the audit.
+ * @param severity - The severity to check.
+ * @returns Whether the severity is in range.
+ */
+export default function severityGreater(
+  inputOptions: InputOptions,
+  severity?: string
+): boolean {
+  // If no level was specified, or the current severity does not exist or
+  // we are using npm with info: include the severity.
+  if (!inputOptions.level || !severity) {
+    return true;
+  }
+  const minimumIndex = severityCascade.indexOf(inputOptions.level);
+  const currentIndex = severityCascade.indexOf(severity);
+  // If for some reason we cannot find the index, include the severity.
+  if (minimumIndex === -1 || currentIndex === -1) {
+    return true;
+  }
+  return currentIndex >= minimumIndex;
+}

--- a/source/static.ts
+++ b/source/static.ts
@@ -1,7 +1,15 @@
+export enum Severity {
+  INFO = 'info',
+  LOW = 'low',
+  MODERATE = 'moderate',
+  HIGH = 'high',
+  CRITICAL = 'critical',
+}
+
 export interface InputOptions {
   cwd?: string;
   yarn?: boolean;
-  level?: 'info' | 'low' | 'moderate' | 'high' | 'critical';
+  level?: Severity;
   dependencyType?: 'devDependencies' | 'dependencies';
   command?: string;
 }


### PR DESCRIPTION
@leeroyrose I decided to fix the `npm` audit level with regex, just so the latest patch for this feature works. For the allow function feature I think I might try and convert to JSON parsing.

fixes: #348